### PR TITLE
[HOT-FIX] Corrige criação de Aluno pela interface do DRf

### DIFF
--- a/amika/permissions.py
+++ b/amika/permissions.py
@@ -12,7 +12,7 @@ class Permissoes(permissions.BasePermission):
 
 
 def pk(request):
-    return {'pk': dict(request.__dict__)['parser_context']['kwargs']['pk']}
+    return {'pk': dict(request.__dict__)['parser_context']['kwargs'].get('pk')}
 
 
 # Usuários


### PR DESCRIPTION
**Descrição da mudança**  
<!-- Descreva de forma clara e concisa sobre a mudança feita. -->
Ao tentar criar o aluno pela interface do Django REST framework, a interface faz um GET na URN ```aluno/```. Com isso, verifica a permissão para esse método e como não há a _pk_ para essa _request_, ele dá erro ao tentar pegar a _pk_ inexistente no dicionário da _request_. Mudei a forma de como pegar o atributo do dicionário, não dando erro caso não exista.

**Tipo da mudança**  
<!-- Marque o checkbox correspondente a mudança. -->
- [x] Correção de bug.
- [ ] Adição de nova fucionalidade.

**Issue relacionada**  
<!-- Adicionar FIX com as issues relacionadas ao abrir o PR. Ex.: Fix #15 -->
FIX #66 

**Screenshots**  
<!-- Se aplicável, adicione imagens da tela para ajudar a explicar a mudança feita. -->
![Captura de Tela 2019-11-04 às 20 17 07](https://user-images.githubusercontent.com/21143590/68166196-5c1e7300-ff40-11e9-9903-373b282b727d.png)

**Informações adicionais**  
<!-- Comente outra informação relevante sobre o seu problema aqui. -->

**Checklist**  
- [x] O pull request possui nome significativo.
- [x] O pull request possui descrição significativa.
- [x] O pull request possui a marcação correspondente ao tipo da mudança.
- [x] O pull request possui screenshots quando necessário.
- [x] O pull request possui labels.
